### PR TITLE
Fix issue of getting BeanCreationException when our maven project build runs integration tests

### DIFF
--- a/doc/mule-module-redis.xml.sample
+++ b/doc/mule-module-redis.xml.sample
@@ -1,6 +1,6 @@
 <!-- BEGIN_INCLUDE(redis:set) -->
 <!-- Use the current message payload as the value to set -->
-<redis:set key="mykey"  muleEvent-ref="ref" />
+<redis:set key="mykey" />
 <!-- END_INCLUDE(redis:set) -->
 
 <!-- BEGIN_INCLUDE(redis:set-value) -->
@@ -35,7 +35,7 @@
 
 <!-- BEGIN_INCLUDE(redis:hash-set) -->
 <!-- Use the current message payload as the value to set -->
-<redis:hash-set key="mykey" field="myfield" muleEvent-ref="ref" />
+<redis:hash-set key="mykey" field="myfield" />
 <!-- END_INCLUDE(redis:hash-set) -->
 
 <!-- BEGIN_INCLUDE(redis:hash-set-value) -->
@@ -57,7 +57,7 @@
 
 
 <!-- BEGIN_INCLUDE(redis:list-push) -->
-<redis:list-push key="my_key" side="RIGHT" muleEvent-ref="ref" />
+<redis:list-push key="my_key" side="RIGHT" />
 <!-- END_INCLUDE(redis:list-push) -->
 
 <!-- BEGIN_INCLUDE(redis:list-push-value) -->
@@ -70,7 +70,7 @@
 
 
 <!-- BEGIN_INCLUDE(redis:set-add) -->
-<redis:set-add key="my_key" muleEvent-ref="ref" />
+<redis:set-add key="my_key" />
 <!-- END_INCLUDE(redis:set-add) -->
 
 <!-- BEGIN_INCLUDE(redis:set-add-value) -->
@@ -86,7 +86,7 @@
 <!-- END_INCLUDE(redis:set-pop) -->
 
 <!-- BEGIN_INCLUDE(redis:sorted-set-add) -->
-<redis:sorted-set-add key="my_key" score="123" muleEvent-ref="ref" />
+<redis:sorted-set-add key="my_key" score="123" />
 <!-- END_INCLUDE(redis:sorted-set-add) -->
 
 <!-- BEGIN_INCLUDE(redis:sorted-set-add-value) -->
@@ -102,7 +102,7 @@
 <!-- END_INCLUDE(redis:sorted-set-select-range-by-score) -->
 
 <!-- BEGIN_INCLUDE(redis:sorted-set-increment) -->
-<redis:sorted-set-increment key="my_key" step="3.14" muleEvent-ref="ref" />
+<redis:sorted-set-increment key="my_key" step="3.14" />
 <!-- END_INCLUDE(redis:sorted-set-increment) -->
 
 <!-- BEGIN_INCLUDE(redis:sorted-set-increment-value) -->
@@ -129,7 +129,7 @@
 
 <!-- BEGIN_INCLUDE(redis:publish) -->
 <!-- Use the current message payload as the message to publish -->
-<redis:publish channel="news.art.figurative" muleEvent-ref="ref" />
+<redis:publish channel="news.art.figurative" />
 <!-- END_INCLUDE(redis:publish) -->
 
 <!-- BEGIN_INCLUDE(redis:publish-message) -->

--- a/doc/mule-module-redis.xml.sample
+++ b/doc/mule-module-redis.xml.sample
@@ -1,6 +1,6 @@
 <!-- BEGIN_INCLUDE(redis:set) -->
 <!-- Use the current message payload as the value to set -->
-<redis:set key="mykey" />
+<redis:set key="mykey"  muleEvent-ref="ref" />
 <!-- END_INCLUDE(redis:set) -->
 
 <!-- BEGIN_INCLUDE(redis:set-value) -->
@@ -35,7 +35,7 @@
 
 <!-- BEGIN_INCLUDE(redis:hash-set) -->
 <!-- Use the current message payload as the value to set -->
-<redis:hash-set key="mykey" field="myfield" />
+<redis:hash-set key="mykey" field="myfield" muleEvent-ref="ref" />
 <!-- END_INCLUDE(redis:hash-set) -->
 
 <!-- BEGIN_INCLUDE(redis:hash-set-value) -->
@@ -57,7 +57,7 @@
 
 
 <!-- BEGIN_INCLUDE(redis:list-push) -->
-<redis:list-push key="my_key" side="RIGHT" />
+<redis:list-push key="my_key" side="RIGHT" muleEvent-ref="ref" />
 <!-- END_INCLUDE(redis:list-push) -->
 
 <!-- BEGIN_INCLUDE(redis:list-push-value) -->
@@ -70,7 +70,7 @@
 
 
 <!-- BEGIN_INCLUDE(redis:set-add) -->
-<redis:set-add key="my_key" />
+<redis:set-add key="my_key" muleEvent-ref="ref" />
 <!-- END_INCLUDE(redis:set-add) -->
 
 <!-- BEGIN_INCLUDE(redis:set-add-value) -->
@@ -86,7 +86,7 @@
 <!-- END_INCLUDE(redis:set-pop) -->
 
 <!-- BEGIN_INCLUDE(redis:sorted-set-add) -->
-<redis:sorted-set-add key="my_key" score="123" />
+<redis:sorted-set-add key="my_key" score="123" muleEvent-ref="ref" />
 <!-- END_INCLUDE(redis:sorted-set-add) -->
 
 <!-- BEGIN_INCLUDE(redis:sorted-set-add-value) -->
@@ -102,7 +102,7 @@
 <!-- END_INCLUDE(redis:sorted-set-select-range-by-score) -->
 
 <!-- BEGIN_INCLUDE(redis:sorted-set-increment) -->
-<redis:sorted-set-increment key="my_key" step="3.14" />
+<redis:sorted-set-increment key="my_key" step="3.14" muleEvent-ref="ref" />
 <!-- END_INCLUDE(redis:sorted-set-increment) -->
 
 <!-- BEGIN_INCLUDE(redis:sorted-set-increment-value) -->
@@ -129,7 +129,7 @@
 
 <!-- BEGIN_INCLUDE(redis:publish) -->
 <!-- Use the current message payload as the message to publish -->
-<redis:publish channel="news.art.figurative" />
+<redis:publish channel="news.art.figurative" muleEvent-ref="ref" />
 <!-- END_INCLUDE(redis:publish) -->
 
 <!-- BEGIN_INCLUDE(redis:publish-message) -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mule.modules</groupId>
     <artifactId>mule-module-redis</artifactId>
-    <version>3.4.1-SNAPSHOT</version>
+    <version>3.4.3-SNAPSHOT</version>
     <packaging>mule-module</packaging>
     <name>Mule Redis Module</name>
     <description>Redis support for Mule</description>
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.mule.tools.devkit</groupId>
         <artifactId>mule-devkit-parent</artifactId>
-        <version>3.4.1</version>
+        <version>3.4.3</version>
     </parent>
     <properties>
         <category>Community</category>
@@ -140,6 +140,12 @@
             <id>mulesoft-releases</id>
             <name>MuleSoft Releases Repository</name>
             <url>http://repository.mulesoft.org/releases/</url>
+            <layout>default</layout>
+        </repository>
+        <repository>
+            <id>mulesoft-releases-nexuspublic</id>
+            <name>MuleSoft Releases Repository NexusPublic</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases/</url>
             <layout>default</layout>
         </repository>
     </repositories>

--- a/src/main/java/org/mule/module/redis/RedisModule.java
+++ b/src/main/java/org/mule/module/redis/RedisModule.java
@@ -173,7 +173,7 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      *         message is returned.
      */
     @Processor
-    @Inject
+    //@Inject
     public byte[] set(final String key,
                       @Optional final Integer expire,
                       @Optional @Default("false") final boolean ifNotExists,
@@ -329,7 +329,7 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      *         new field is created the message is returned.
      */
     @Processor(name = "hash-set")
-    @Inject
+    //@Inject
     public byte[] setInHash(final String key,
                             final String field,
                             @Optional @Default("false") final boolean ifNotExists,
@@ -502,7 +502,7 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      *         the message is returned.
      */
     @Processor(name = "list-push")
-    @Inject
+    //@Inject
     public byte[] pushToList(final String key,
                              final ListPushSide side,
                              @Optional @Default("false") final boolean ifExists,
@@ -561,7 +561,7 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      *         Otherwise the message is returned.
      */
     @Processor(name = "set-add")
-    @Inject
+    //@Inject
     public byte[] addToSet(final String key,
                            @Optional @Default("false") final boolean mustSucceed,
                            @Optional @Default("#[message.payloadAs(java.lang.String)]") final String value,
@@ -647,7 +647,7 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      *         returned. Otherwise the message is returned.
      */
     @Processor(name = "sorted-set-add")
-    @Inject
+    //@Inject
     public byte[] addToSortedSet(final String key,
                                  final double score,
                                  @Optional @Default("false") final boolean mustSucceed,
@@ -793,7 +793,7 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      * @return the new score of the member.
      */
     @Processor(name = "sorted-set-increment")
-    @Inject
+    //@Inject
     public Double incrementSortedSet(final String key,
                                      final double step,
                                      @Optional @Default("#[message.payloadAs(java.lang.String)]") final String value,
@@ -926,7 +926,7 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      *         returned. Otherwise the message is returned.
      */
     @Processor
-    @Inject
+    //@Inject
     public byte[] publish(final String channel,
                           @Optional @Default("false") final boolean mustSucceed,
                           @Optional @Default("#[message.payloadAs(java.lang.String)]") final String message,


### PR DESCRIPTION
This is to fix the issue discussed in the (long) issue thread:
[BeanCreationException: Could not autowire method: public byte[] org.mule.module.redis.RedisModule.set(...)]
(https://github.com/mulesoft/redis-connector/issues/3). We acknowledge and appreciate the help given by David Dossot.

There are three relatively small sub-commits done over the many days, each addressing a particular challenge that had to be overcome as we try to debug and find a reasonable fix that works for our mule project.

We see the BeanCreationException when our maven project build runs integration tests; the project is large, and not easy to reduce the project to something simple that can reproduce the exception being thrown.

To try to provide some background on our project, I'll copy/paste at bottom from one of my comments in the issue thread in reply to a question by David Dossot.

The fix in this pull request removes the @Inject annotation from seven api methods in the RedisModule class. However, in order for the redis connector to still work in a mule xml flow, we needed to provide a MuleEvent object to those seven api methods, but instead of providing that as one of the method arguments autowired by @Inject, we remove the need for that argument by providing the MuleEvent object within those seven methods.

I have tested the resulting redis connector using the redis example project that David wrote up in his blog [Mule and Redis get a web bug] (http://blogs.mulesoft.org/mule-and-redis-get-a-web-bug/), but changing to Operation "Set" instead of "Increment hash" since the increment hash method is not one of the seven api methods in RedisModule affected by this fix, but the set method is one of those seven api methods. I did not do more testing involving the other six api methods because I have doubts whether MuleSoft would accept this pull request, but would be happy to do so if this pull request is reviewed positively for merging into master branch.

Finally, in the project pom, I arbitrarily named the repository https://repository.mulesoft.org/nexus/content/repositories/releases/ as "MuleSoft Releases Repository NexusPublic"; that probably should be reviewed for internal consistency by MuleSoft staff.

Thanks for your consideration.

Below is some background on our large mule project where we ran into above problem, copy/paste from one of my comments in the issue thread:
...
a) We have a large subsystem currently running Mule 3.4.0 CE that has been in Production for about a year now. That subsystem currently specifies in the project pom the dependency: mule-module-redis version 3.3.3-SNAPSHOT, so I was just trying to work down the Tech Debt and see what it would take to upgrade. So, hoping not to do wholesale refactoring or re-design for what had looked like just upgrading to a later version 3.4.0 mule-module-redis, at least not for now.
b) That project uses Mule flow, Spring beans for DI, and Java POJO classes.

1) I don't believe 'org.mule.module.redis' package gets scanned, as you commented, since our beans config file has only:
<pre><code>
    &lt;context:annotation-config /&gt;
    &lt;context:component-scan base-package="com.jumptap.mephesto,com.jumptap.mule" /&gt;
</code></pre>
But, to try to throw more light, we do have our own redis adapter class that in in a package that does get scanned, and that redis adapter singleton uses Spring to inject in a RedisModule object named "globalredis' as a class property (field).
<pre><code>
      &lt;spring:property name="redisModule" ref="globalredis"/&gt;
</code></pre>

 That RedisModule object is specified by
<pre><code>
    &lt;redis:config 
        name="globalredis"
        connectionTimeout="${redis.connectionTimeout}"
        host="${redis.host}"
        password="${redis.password}"
        port="${redis.port}"
        reconnectionFrequency="${redis.reconnectionFrequency}"
        poolConfig-ref="jedisConfig"
    /&gt;
</code></pre>

2) So to answer you second bullet point, Mule (via redis:config) does the instantiation of the RedisModule object/bean.

I do take your point that since we only call RedisModule methods in Java (from within that redis adapter class), maybe we shouldn't be using the redis-connector. There are a number of wrapper methods that you've written in RedisModule that we take advantage of in our redis adapter class, such as
  redisModule.set(...)
  redisModule.get(...)
even
  RedisUtils.run(redisModule.getJedisPool(), new RedisAction<Long>() {...});
so that's probably part of the reason for the initial design choice to make use of mule-module-redis.

