### PR TITLE
Upgrade to Jedis 2.8.0 and devkit 3.7.2 and Sentinel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /*.iws
 /target
 /classes
+.factorypath

--- a/doc/Overview.md
+++ b/doc/Overview.md
@@ -32,21 +32,30 @@ If you need to refer to this configuration (in case you have several different c
 
     <redis:config name="localRedis" />
 
-The following demonstrates all the possible configuration options:
+The following demonstrates one example of advanced configuration:
 
     <spring:beans>
-        <spring:bean name="redisPoolConfiguration"
-                     class="redis.clients.jedis.JedisPoolConfig"
-                     p:whenExhaustedAction="#{T(org.apache.commons.pool.impl.GenericObjectPool).WHEN_EXHAUSTED_GROW}" />
+        <spring:bean name="redisPoolConfiguration" class="org.apache.commons.pool2.impl.GenericObjectPoolConfig"
+            p:blockWhenExhausted="true" />
     </spring:beans>
     
     <redis:config name="localRedis"
                   host="localhost"
                   port="6379"
                   password="s3cre3t"
-                  connectionTimeout="15000"
-                  poolConfig-ref="redisPoolConfiguration" />
+                  connectionTimeout="15000">
+         <redis:pool-config ref="redisPoolConfiguration"/>
+     </redis:config>
+     
+If you want to connect to Sentinel to support Master/Slave Redis configuration you can do it in the following way
 
+    <redis:config name="localRedis" connectionTimeout="15000">
+        <redis:sentinels>
+            <redis:sentinel>127.0.0.1:5001</redis:sentinel>
+            <redis:sentinel>127.0.0.1:5002</redis:sentinel>
+            <redis:sentinel>127.0.0.1:5003</redis:sentinel>
+        </redis:sentinels>
+    </redis:config>
 
 ### Datastructure Operations
 
@@ -147,3 +156,8 @@ For example, the following shows how to use the Redis module as the data store f
 
     <redis:config name="localRedis" />
     <pubsubhubbub:config objectStore-ref="localRedis" />
+   
+When using the Redis module has object store you can also specify a custom partition name and an expiration time in seconds that are useful when doing enterprise caching
+
+    <redis:config name="localRedis" partitionExpiry="5" defaultPartitionName="mypartition"/>
+

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.mule.tools.devkit</groupId>
         <artifactId>mule-devkit-parent</artifactId>
-        <version>3.8.0</version>
+        <version>3.7.2</version>
     </parent>
     <properties>
         <category>Community</category>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.mule.tools.devkit</groupId>
         <artifactId>mule-devkit-parent</artifactId>
-        <version>3.4.1</version>
+        <version>3.8.0</version>
     </parent>
     <properties>
         <category>Community</category>
@@ -30,11 +30,11 @@
 
         <!-- Other Dependencies -->
         <dependency>
-            <groupId>redis.clients</groupId>
-            <artifactId>jedis</artifactId>
-            <version>2.1.0</version>
-            <type>jar</type>
-        </dependency>
+			<groupId>redis.clients</groupId>
+			<artifactId>jedis</artifactId>
+			<version>2.8.0</version>
+			<type>jar</type>
+		</dependency>
 
         <!-- Testing Dependencies -->
         <dependency>

--- a/src/main/java/org/mule/module/redis/RedisModule.java
+++ b/src/main/java/org/mule/module/redis/RedisModule.java
@@ -1171,14 +1171,12 @@ public class RedisModule implements PartitionableObjectStore<Serializable>
     
 	@Override
 	public void clear() throws ObjectStoreException {
-		// TODO Auto-generated method stub
-		
+		this.disposePartition(FALLBACK_PARTITION_NAME);
 	}
 
 	@Override
-	public void clear(String arg0) throws ObjectStoreException {
-		// TODO Auto-generated method stub
-		
+	public void clear(String partitionName) throws ObjectStoreException {
+		this.disposePartition(partitionName);
 	}
 
     /*----------------------------------------------------------

--- a/src/main/java/org/mule/module/redis/RedisModule.java
+++ b/src/main/java/org/mule/module/redis/RedisModule.java
@@ -93,9 +93,8 @@ public class RedisModule implements PartitionableObjectStore<Serializable>
     	System.out.println("CHAAGEEEEED");
     	//Looks like post construct is called twice, would be nice to understand why
     	if(jedisPool == null){
-    		
     		if (config.getSentinels().size()>1) {
-    			jedisPool = new JedisSentinelPool("mymaster", config.getSentinels(), config.getPoolConfig(), config.getConnectionTimeout(), config.getPassword());
+    			jedisPool = new JedisSentinelPool("mymaster", config.getSentinels(), config.getPoolConfig(), config.getConnectionTimeout(), StringUtils.repeat("*", StringUtils.length(config.getPassword())));
     			
     			LOGGER.info(String.format(
     		            "Redis connector ready, Sentinels: %s, timeout: %d, password: %s, pool config: %s", config.getSentinels().toArray(new String[config.getSentinels().size()]), config.getConnectionTimeout(), StringUtils.repeat("*", StringUtils.length(config.getPassword())),

--- a/src/main/java/org/mule/module/redis/RedisModule.java
+++ b/src/main/java/org/mule/module/redis/RedisModule.java
@@ -15,7 +15,6 @@ import java.util.Set;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import javax.inject.Inject;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
@@ -173,7 +172,6 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      *         message is returned.
      */
     @Processor
-    @Inject
     public byte[] set(final String key,
                       @Optional final Integer expire,
                       @Optional @Default("false") final boolean ifNotExists,
@@ -329,7 +327,6 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      *         new field is created the message is returned.
      */
     @Processor(name = "hash-set")
-    @Inject
     public byte[] setInHash(final String key,
                             final String field,
                             @Optional @Default("false") final boolean ifNotExists,
@@ -502,7 +499,6 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      *         the message is returned.
      */
     @Processor(name = "list-push")
-    @Inject
     public byte[] pushToList(final String key,
                              final ListPushSide side,
                              @Optional @Default("false") final boolean ifExists,
@@ -561,7 +557,6 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      *         Otherwise the message is returned.
      */
     @Processor(name = "set-add")
-    @Inject
     public byte[] addToSet(final String key,
                            @Optional @Default("false") final boolean mustSucceed,
                            @Optional @Default("#[message.payloadAs(java.lang.String)]") final String value,
@@ -647,7 +642,6 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      *         returned. Otherwise the message is returned.
      */
     @Processor(name = "sorted-set-add")
-    @Inject
     public byte[] addToSortedSet(final String key,
                                  final double score,
                                  @Optional @Default("false") final boolean mustSucceed,
@@ -793,7 +787,6 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      * @return the new score of the member.
      */
     @Processor(name = "sorted-set-increment")
-    @Inject
     public Double incrementSortedSet(final String key,
                                      final double step,
                                      @Optional @Default("#[message.payloadAs(java.lang.String)]") final String value,
@@ -926,7 +919,6 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      *         returned. Otherwise the message is returned.
      */
     @Processor
-    @Inject
     public byte[] publish(final String channel,
                           @Optional @Default("false") final boolean mustSucceed,
                           @Optional @Default("#[message.payloadAs(java.lang.String)]") final String message,

--- a/src/main/java/org/mule/module/redis/RedisModule.java
+++ b/src/main/java/org/mule/module/redis/RedisModule.java
@@ -16,16 +16,16 @@ import java.util.Set;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.commons.pool.impl.GenericObjectPool.Config;
 import org.mule.RequestContext;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
 import org.mule.api.annotations.Configurable;
-import org.mule.api.annotations.Module;
+import org.mule.api.annotations.Connector;
 import org.mule.api.annotations.Processor;
 import org.mule.api.annotations.Source;
 import org.mule.api.annotations.param.Default;
@@ -42,10 +42,10 @@ import org.mule.module.redis.RedisUtils.RedisAction;
 import org.mule.util.StringUtils;
 
 import redis.clients.jedis.BinaryJedis;
-import redis.clients.jedis.BinaryTransaction;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.Response;
+import redis.clients.jedis.Transaction;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.util.SafeEncoder;
 
@@ -60,8 +60,8 @@ import redis.clients.util.SafeEncoder;
  * 
  * @author MuleSoft, Inc.
  */
-@SuppressWarnings("deprecation")
-@Module(name = "redis", schemaVersion = "3.4", friendlyName = "Redis", minMuleVersion = "3.4.0", description = "Redis Module")
+
+@Connector(name = "redis", schemaVersion = "3.4", friendlyName = "Redis", minMuleVersion = "3.4.0", description = "Redis Module")
 public class RedisModule implements PartitionableObjectStore<Serializable>, MuleContextAware
 {
     private static final String FALLBACK_PARTITION_NAME = "_default";
@@ -112,7 +112,7 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
      */
     @Configurable
     @Optional
-    private Config poolConfig = new JedisPoolConfig();
+    private GenericObjectPoolConfig poolConfig = new JedisPoolConfig();
 
     /**
      * The {@link PartitionableObjectStore} partition to use in case methods from
@@ -1130,7 +1130,7 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
             {
                 final byte[] keyAsBytes = RedisUtils.toBytes(key);
 
-                final BinaryTransaction t = redis.multi();
+                final Transaction t = redis.multi();
                 final Response<byte[]> getResult = t.hget(RedisUtils.getPartitionHashKey(partitionName),
                     keyAsBytes);
                 final Response<Long> delResult = t.hdel(RedisUtils.getPartitionHashKey(partitionName),
@@ -1282,12 +1282,12 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
         this.defaultPartitionName = defaultPartitionName;
     }
 
-    public Config getPoolConfig()
+    public GenericObjectPoolConfig getPoolConfig()
     {
         return poolConfig;
     }
 
-    public void setPoolConfig(final Config poolConfig)
+    public void setPoolConfig(final GenericObjectPoolConfig poolConfig)
     {
         this.poolConfig = poolConfig;
     }
@@ -1302,4 +1302,16 @@ public class RedisModule implements PartitionableObjectStore<Serializable>, Mule
     {
         this.muleContext = muleContext;
     }
+
+	@Override
+	public void clear() throws ObjectStoreException {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void clear(String arg0) throws ObjectStoreException {
+		// TODO Auto-generated method stub
+		
+	}
 }

--- a/src/main/java/org/mule/module/redis/RedisModule.java
+++ b/src/main/java/org/mule/module/redis/RedisModule.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.mule.DefaultMuleMessage;
 import org.mule.RequestContext;
 import org.mule.api.MuleContext;
 import org.mule.api.MuleEvent;
@@ -1064,6 +1065,14 @@ public class RedisModule implements PartitionableObjectStore<Serializable>
         {
             throw new ObjectDoesNotExistException(
                 MessageFactory.createStaticMessage("No value found for key: " + key));
+        }
+        
+        //This is needed when using the component has object store for a mule ee cache block
+        //Normally this should be done on mule ee cache component, but is not the case for the moment
+        if (result instanceof MuleEvent) {
+			final MuleEvent sourceEvent = (MuleEvent) result;
+			((DefaultMuleMessage) sourceEvent.getMessage()).setMuleContext(muleContext);
+			return sourceEvent;
         }
 
         return result;

--- a/src/main/java/org/mule/module/redis/RedisUtils.java
+++ b/src/main/java/org/mule/module/redis/RedisUtils.java
@@ -19,7 +19,7 @@ import org.apache.commons.logging.LogFactory;
 
 import redis.clients.jedis.BinaryJedis;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
+import redis.clients.util.Pool;
 import redis.clients.util.SafeEncoder;
 
 public abstract class RedisUtils
@@ -114,7 +114,7 @@ public abstract class RedisUtils
         return patterns;
     }
 
-    public static <R> R run(final JedisPool jedisPool, final RedisAction<R> action)
+    public static <R> R run(final Pool<Jedis> jedisPool, final RedisAction<R> action)
     {
     	try (Jedis jedis = jedisPool.getResource()) {
     		return action.runWithJedis(jedis);

--- a/src/main/java/org/mule/module/redis/RedisUtils.java
+++ b/src/main/java/org/mule/module/redis/RedisUtils.java
@@ -20,7 +20,6 @@ import org.apache.commons.logging.LogFactory;
 import redis.clients.jedis.BinaryJedis;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.util.SafeEncoder;
 
 public abstract class RedisUtils
@@ -117,32 +116,8 @@ public abstract class RedisUtils
 
     public static <R> R run(final JedisPool jedisPool, final RedisAction<R> action)
     {
-        final Jedis jedis = jedisPool.getResource();
-        boolean brokenResource = false;
-
-        try
-        {
-            try
-            {
-                return action.runWithJedis(jedis);
-            }
-            catch (final JedisConnectionException jce)
-            {
-                brokenResource = true;
-                throw jce;
-            }
+    	try (Jedis jedis = jedisPool.getResource()) {
+    		return action.runWithJedis(jedis);
         }
-        finally
-        {
-            if (brokenResource)
-            {
-                jedisPool.returnBrokenResource(jedis);
-            }
-            else
-            {
-                jedisPool.returnResource(jedis);
-            }
-        }
-
     }
 }

--- a/src/main/java/org/mule/module/redis/config/ConnectorConfig.java
+++ b/src/main/java/org/mule/module/redis/config/ConnectorConfig.java
@@ -1,8 +1,12 @@
 package org.mule.module.redis.config;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.mule.api.annotations.Configurable;
 import org.mule.api.annotations.components.Configuration;
+import org.mule.api.annotations.display.Placement;
 import org.mule.api.annotations.param.Default;
 import org.mule.api.annotations.param.Optional;
 import org.mule.api.store.ObjectStore;
@@ -18,6 +22,7 @@ public class ConnectorConfig {
      */
     @Configurable
     @Default("localhost")
+    @Placement(order = 0, group = "Connection")
     private String host;
 
     /**
@@ -25,6 +30,7 @@ public class ConnectorConfig {
      */
     @Configurable
     @Default("6379")
+    @Placement(order = 1, group = "Connection")
     private int port;
 
     /**
@@ -32,6 +38,7 @@ public class ConnectorConfig {
      */
     @Configurable
     @Default("2000")
+    @Placement(order = 3, group = "Connection")
     private int connectionTimeout;
 
     /**
@@ -39,6 +46,7 @@ public class ConnectorConfig {
      */
     @Configurable
     @Default("5000")
+    @Placement(order = 4, group = "Connection")
     private int reconnectionFrequency;
 
     /**
@@ -46,6 +54,7 @@ public class ConnectorConfig {
      */
     @Configurable
     @Optional
+    @Placement(order = 2, group = "Connection")
     private String password;
 
     /**
@@ -53,6 +62,7 @@ public class ConnectorConfig {
      */
     @Configurable
     @Optional
+    @Placement(order = 5, group = "Connection")
     private GenericObjectPoolConfig poolConfig = new JedisPoolConfig();
 
     /**
@@ -61,15 +71,24 @@ public class ConnectorConfig {
      */
     @Configurable
     @Optional
+    @Placement(order = 0, group = "General", tab = "ObjectStore")
     private String defaultPartitionName;
     
 	/**
-	 * The expiration of the cache partition in seconds. 0 means no expiration.
-	 * Default value is 0.
+	 * The expiration of the {@link ObjectStore} cache partition in seconds
 	 */
     @Configurable
     @Optional
+    @Placement(order = 1, group = "General", tab = "ObjectStore")
 	private int partitionExpiry = 0;
+    
+	/**
+	 * The set of sentinel servers to connect to
+	 */
+    @Configurable
+    @Optional
+    @Placement(order = 0, group = "Sentinel")
+	private Set<String> sentinels = new HashSet<String>();
 
 	public String getHost() {
 		return host;
@@ -133,6 +152,14 @@ public class ConnectorConfig {
 
 	public void setPartitionExpiry(int partitionExpiry) {
 		this.partitionExpiry = partitionExpiry;
+	}
+
+	public Set<String> getSentinels() {
+		return sentinels;
+	}
+
+	public void setSentinels(Set<String> sentinels) {
+		this.sentinels = sentinels;
 	}
 	
 }

--- a/src/main/java/org/mule/module/redis/config/ConnectorConfig.java
+++ b/src/main/java/org/mule/module/redis/config/ConnectorConfig.java
@@ -3,7 +3,6 @@ package org.mule.module.redis.config;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.mule.api.annotations.Configurable;
 import org.mule.api.annotations.components.Configuration;
-import org.mule.api.annotations.display.Placement;
 import org.mule.api.annotations.param.Default;
 import org.mule.api.annotations.param.Optional;
 import org.mule.api.store.ObjectStore;
@@ -18,8 +17,6 @@ public class ConnectorConfig {
      * Redis host.
      */
     @Configurable
-    @Optional
-    @Placement(order = 0, group = "General", tab = "Single instance")
     @Default("localhost")
     private String host;
 
@@ -27,8 +24,6 @@ public class ConnectorConfig {
      * Redis port.
      */
     @Configurable
-    @Optional
-    @Placement(order = 0, group = "General", tab = "Single instance")
     @Default("6379")
     private int port;
 
@@ -36,7 +31,6 @@ public class ConnectorConfig {
      * Connection timeout in milliseconds.
      */
     @Configurable
-    @Optional
     @Default("2000")
     private int connectionTimeout;
 
@@ -44,7 +38,6 @@ public class ConnectorConfig {
      * Reconnection frequency in milliseconds.
      */
     @Configurable
-    @Optional
     @Default("5000")
     private int reconnectionFrequency;
 

--- a/src/main/java/org/mule/module/redis/config/ConnectorConfig.java
+++ b/src/main/java/org/mule/module/redis/config/ConnectorConfig.java
@@ -1,0 +1,129 @@
+package org.mule.module.redis.config;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.mule.api.annotations.Configurable;
+import org.mule.api.annotations.components.Configuration;
+import org.mule.api.annotations.display.Placement;
+import org.mule.api.annotations.param.Default;
+import org.mule.api.annotations.param.Optional;
+import org.mule.api.store.ObjectStore;
+import org.mule.api.store.PartitionableObjectStore;
+
+import redis.clients.jedis.JedisPoolConfig;
+
+@Configuration(friendlyName = "Configuration")
+public class ConnectorConfig {
+	
+	 /**
+     * Redis host.
+     */
+    @Configurable
+    @Optional
+    @Placement(order = 0, group = "General", tab = "Single instance")
+    @Default("localhost")
+    private String host;
+
+    /**
+     * Redis port.
+     */
+    @Configurable
+    @Optional
+    @Placement(order = 0, group = "General", tab = "Single instance")
+    @Default("6379")
+    private int port;
+
+    /**
+     * Connection timeout in milliseconds.
+     */
+    @Configurable
+    @Optional
+    @Default("2000")
+    private int connectionTimeout;
+
+    /**
+     * Reconnection frequency in milliseconds.
+     */
+    @Configurable
+    @Optional
+    @Default("5000")
+    private int reconnectionFrequency;
+
+    /**
+     * Redis password
+     */
+    @Configurable
+    @Optional
+    private String password;
+
+    /**
+     * Object pool configuration.
+     */
+    @Configurable
+    @Optional
+    private GenericObjectPoolConfig poolConfig = new JedisPoolConfig();
+
+    /**
+     * The {@link PartitionableObjectStore} partition to use in case methods from
+     * {@link ObjectStore} are used.
+     */
+    @Configurable
+    @Optional
+    private String defaultPartitionName;
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public int getConnectionTimeout() {
+		return connectionTimeout;
+	}
+
+	public void setConnectionTimeout(int connectionTimeout) {
+		this.connectionTimeout = connectionTimeout;
+	}
+
+	public int getReconnectionFrequency() {
+		return reconnectionFrequency;
+	}
+
+	public void setReconnectionFrequency(int reconnectionFrequency) {
+		this.reconnectionFrequency = reconnectionFrequency;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public GenericObjectPoolConfig getPoolConfig() {
+		return poolConfig;
+	}
+
+	public void setPoolConfig(GenericObjectPoolConfig poolConfig) {
+		this.poolConfig = poolConfig;
+	}
+
+	public String getDefaultPartitionName() {
+		return defaultPartitionName;
+	}
+
+	public void setDefaultPartitionName(String defaultPartitionName) {
+		this.defaultPartitionName = defaultPartitionName;
+	}
+
+}

--- a/src/main/java/org/mule/module/redis/config/ConnectorConfig.java
+++ b/src/main/java/org/mule/module/redis/config/ConnectorConfig.java
@@ -69,6 +69,14 @@ public class ConnectorConfig {
     @Configurable
     @Optional
     private String defaultPartitionName;
+    
+	/**
+	 * The expiration of the cache partition in seconds. 0 means no expiration.
+	 * Default value is 0.
+	 */
+    @Configurable
+    @Optional
+	private int partitionExpiry = 0;
 
 	public String getHost() {
 		return host;
@@ -126,4 +134,12 @@ public class ConnectorConfig {
 		this.defaultPartitionName = defaultPartitionName;
 	}
 
+	public int getPartitionExpiry() {
+		return partitionExpiry;
+	}
+
+	public void setPartitionExpiry(int partitionExpiry) {
+		this.partitionExpiry = partitionExpiry;
+	}
+	
 }

--- a/src/test/java/org/mule/module/redis/RedisDataStructureITCase.java
+++ b/src/test/java/org/mule/module/redis/RedisDataStructureITCase.java
@@ -56,10 +56,10 @@ public class RedisDataStructureITCase extends FunctionalTestCase
         final String testKey = TEST_KEY_PREFIX + UUID.getUUID();
 
         assertFalse(muleClient.send("vm://key-existence.in", "ignored",
-            Collections.singletonMap(KEY_PROP, testKey)).getPayload(Boolean.class));
+            Collections.singletonMap(KEY_PROP, (Object)testKey)).getPayload(Boolean.class));
 
         final MuleMessageCollection writerResults = (MuleMessageCollection) muleClient.send(
-            "vm://strings-writer.in", testPayload, Collections.singletonMap(KEY_PROP, testKey));
+            "vm://strings-writer.in", testPayload, Collections.singletonMap(KEY_PROP, (Object)testKey));
 
         assertEquals(6, writerResults.size());
         assertTrue(writerResults.getMessage(0).getPayload() instanceof byte[]);
@@ -76,22 +76,22 @@ public class RedisDataStructureITCase extends FunctionalTestCase
         Thread.sleep(2000L);
 
         assertTrue(muleClient.send("vm://key-existence.in", "ignored",
-            Collections.singletonMap(KEY_PROP, testKey)).getPayload(Boolean.class));
+            Collections.singletonMap(KEY_PROP, (Object)testKey)).getPayload(Boolean.class));
         assertEquals(testPayload,
-            muleClient.send("vm://strings-reader.in", "ignored", Collections.singletonMap(KEY_PROP, testKey))
+            muleClient.send("vm://strings-reader.in", "ignored", Collections.singletonMap(KEY_PROP, (Object)testKey))
                 .getPayloadAsString());
         assertEquals(
             NullPayload.getInstance(),
             muleClient.send("vm://strings-reader.in", "ignored",
-                Collections.singletonMap(KEY_PROP, testKey + ".ttl")).getPayload());
+                Collections.singletonMap(KEY_PROP, (Object)(testKey + ".ttl"))).getPayload());
         assertEquals(
             testPayload,
             muleClient.send("vm://strings-reader.in", "ignored",
-                Collections.singletonMap(KEY_PROP, testKey + ".other")).getPayloadAsString());
+                Collections.singletonMap(KEY_PROP, (Object)(testKey + ".other"))).getPayloadAsString());
         assertEquals(
             testKey,
             muleClient.send("vm://strings-reader.in", "ignored",
-                Collections.singletonMap(KEY_PROP, testKey + ".value")).getPayloadAsString());
+                Collections.singletonMap(KEY_PROP, (Object)(testKey + ".value"))).getPayloadAsString());
     }
 
     @Test
@@ -100,7 +100,7 @@ public class RedisDataStructureITCase extends FunctionalTestCase
         final String testPayload = RandomStringUtils.randomAlphanumeric(20);
         final String testKey = TEST_KEY_PREFIX + UUID.getUUID();
         final MuleMessage response = muleClient.send("vm://incr-decr.in", testPayload,
-            Collections.singletonMap(KEY_PROP, testKey));
+            Collections.singletonMap(KEY_PROP, (Object)testKey));
 
         assertEquals(-2L, response.getPayload());
     }
@@ -112,7 +112,7 @@ public class RedisDataStructureITCase extends FunctionalTestCase
         final String testKey = TEST_KEY_PREFIX + UUID.getUUID();
         final String testField = UUID.getUUID();
 
-        final Map<String, String> props = new HashMap<String, String>();
+        final Map<String, Object> props = new HashMap<String, Object>();
         props.put(KEY_PROP, testKey);
         props.put(FIELD_PROP, testField);
 
@@ -136,7 +136,7 @@ public class RedisDataStructureITCase extends FunctionalTestCase
         final String testKey = TEST_KEY_PREFIX + UUID.getUUID();
         final String testField = UUID.getUUID();
 
-        final Map<String, String> props = new HashMap<String, String>();
+        final Map<String, Object> props = new HashMap<String, Object>();
         props.put(KEY_PROP, testKey);
         props.put(FIELD_PROP, testField);
 
@@ -150,9 +150,9 @@ public class RedisDataStructureITCase extends FunctionalTestCase
     {
         final String testPayload = RandomStringUtils.randomAlphanumeric(20);
         final String testKey = TEST_KEY_PREFIX + UUID.getUUID();
-        muleClient.send("vm://lists-writer.in", testPayload, Collections.singletonMap(KEY_PROP, testKey));
+        muleClient.send("vm://lists-writer.in", testPayload, Collections.singletonMap(KEY_PROP, (Object)testKey));
 
-        final Map<String, String> props = new HashMap<String, String>();
+        final Map<String, Object> props = new HashMap<String, Object>();
         props.put(KEY_PROP, testKey);
         props.put(SIDE_PROP, "LEFT");
         assertEquals(testPayload, muleClient.send("vm://lists-reader.in", "ignored", props)
@@ -172,7 +172,7 @@ public class RedisDataStructureITCase extends FunctionalTestCase
         final String testKey = TEST_KEY_PREFIX + UUID.getUUID();
 
         final MuleMessageCollection writerResults = (MuleMessageCollection) muleClient.send(
-            "vm://sets-writer.in", testPayload, Collections.singletonMap(KEY_PROP, testKey));
+            "vm://sets-writer.in", testPayload, Collections.singletonMap(KEY_PROP, (Object)testKey));
         assertEquals(4, writerResults.size());
         assertEquals(testPayload, writerResults.getMessage(0).getPayloadAsString());
         assertEquals(NullPayload.getInstance(), writerResults.getMessage(1).getPayload());
@@ -180,7 +180,7 @@ public class RedisDataStructureITCase extends FunctionalTestCase
         assertEquals(testKey, writerResults.getMessage(3).getPayloadAsString());
 
         final MuleMessageCollection readerResults = (MuleMessageCollection) muleClient.send(
-            "vm://sets-reader.in", "ignored", Collections.singletonMap(KEY_PROP, testKey));
+            "vm://sets-reader.in", "ignored", Collections.singletonMap(KEY_PROP, (Object)testKey));
         assertEquals(4, readerResults.size());
         assertEquals(testPayload, readerResults.getMessage(0).getPayloadAsString());
         assertEquals(testPayload, readerResults.getMessage(1).getPayloadAsString());
@@ -194,7 +194,7 @@ public class RedisDataStructureITCase extends FunctionalTestCase
         String testPayload = RandomStringUtils.randomAlphanumeric(20);
         final String testKey = TEST_KEY_PREFIX + UUID.getUUID();
 
-        final Map<String, String> props = new HashMap<String, String>();
+        final Map<String, Object> props = new HashMap<String, Object>();
         props.put(KEY_PROP, testKey);
         props.put("score", "1");
         MuleMessageCollection writerResults = (MuleMessageCollection) muleClient.send(
@@ -216,7 +216,7 @@ public class RedisDataStructureITCase extends FunctionalTestCase
         assertEquals(testKey, writerResults.getMessage(3).getPayloadAsString());
 
         final MuleMessageCollection readerResults = (MuleMessageCollection) muleClient.send(
-            "vm://sorted-sets-reader.in", "ignored", Collections.singletonMap(KEY_PROP, testKey));
+            "vm://sorted-sets-reader.in", "ignored", Collections.singletonMap(KEY_PROP, (Object)testKey));
         assertEquals(4, readerResults.size());
         for (int i = 0; i < 4; i++)
         {
@@ -233,14 +233,13 @@ public class RedisDataStructureITCase extends FunctionalTestCase
         final String testKey = TEST_KEY_PREFIX + UUID.getUUID();
 
         final MuleMessageCollection writerResults = (MuleMessageCollection) muleClient.send(
-            "vm://sorted-set-incr.in", testPayload, Collections.singletonMap(KEY_PROP, testKey));
+            "vm://sorted-set-incr.in", testPayload, Collections.singletonMap(KEY_PROP, (Object)testKey));
 
         assertEquals(2, writerResults.size());
         assertEquals(3.14, writerResults.getMessage(0).getPayload());
         assertEquals(2.72, writerResults.getMessage(1).getPayload());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testKeyVolatility() throws Exception
     {
@@ -248,8 +247,10 @@ public class RedisDataStructureITCase extends FunctionalTestCase
         final Long expireAtUnixTime = System.currentTimeMillis() / 1000L + 20L;
         final Map<String, ? extends Object> properties = MapUtils.mapWithKeysAndValues(HashMap.class,
             Arrays.asList(KEY_PROP, "expireAtUnixTime"), Arrays.asList(testKey, expireAtUnixTime));
+        final Map<String, Object> props = new HashMap<String, Object>();
+        props.putAll(properties);
         final MuleMessageCollection keyVolatilityResults = (MuleMessageCollection) muleClient.send(
-            "vm://key-volatility.in", "ignored", properties);
+            "vm://key-volatility.in", (Object)"ignored", props);
         assertEquals(5, keyVolatilityResults.size());
 
         final Object[] expectedResults = {true, true, 20L, true, -1L};

--- a/src/test/java/org/mule/module/redis/RedisUtilsTest.java
+++ b/src/test/java/org/mule/module/redis/RedisUtilsTest.java
@@ -59,7 +59,6 @@ public class RedisUtilsTest
         });
         assertEquals("Hello", result);
         verify(poolMock).getResource();
-        verify(poolMock).returnResource(any(Jedis.class));
     }
 
     @Test
@@ -83,7 +82,6 @@ public class RedisUtilsTest
             //OK
         }
         verify(poolMock).getResource();
-        verify(poolMock).returnBrokenResource(any(Jedis.class));
     }
 
 }

--- a/src/test/resources/automation-credentials.properties
+++ b/src/test/resources/automation-credentials.properties
@@ -1,0 +1,8 @@
+#
+# This is an auto-generated file based on the Connector Testing Framework.
+# Please uncomment the lines and complete it accordingly.
+# 14:48:37 - 29/02/2016
+#
+#config-type.greeting= (optional)
+config-type.name=config
+#config-type.reply= (optional)

--- a/src/test/resources/redis-datastructures-tests-config.xml
+++ b/src/test/resources/redis-datastructures-tests-config.xml
@@ -5,43 +5,43 @@
           http://www.mulesoft.org/schema/mule/redis http://www.mulesoft.org/schema/mule/redis/current/mule-redis.xsd
           http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd">
 
-    <redis:config />
+    <redis:config name="localRedis"/>
 
     <flow name="strings-writer">
         <vm:inbound-endpoint path="strings-writer.in"
             exchange-pattern="request-response" />
         <all>
-            <redis:set key="#[message.inboundProperties.key]" />
-            <redis:set key="#[message.inboundProperties.key].ttl"
+            <redis:set config-ref="localRedis" key="#[message.inboundProperties.key]"/>
+            <redis:set config-ref="localRedis" key="#[message.inboundProperties.key].ttl"
                 expire="1" />
-            <redis:set key="#[message.inboundProperties.key].other"
+            <redis:set config-ref="localRedis" key="#[message.inboundProperties.key].other"
                 ifNotExists="true" />
             <append-string-transformer message=".foo" />
-            <redis:set key="#[message.inboundProperties.key]"
+            <redis:set config-ref="localRedis" key="#[message.inboundProperties.key]"
                 ifNotExists="true" />
-            <redis:set key="#[message.inboundProperties.key].value"
+            <redis:set config-ref="localRedis" key="#[message.inboundProperties.key].value"
                 value="#[message.inboundProperties.key]" />
         </all>
     </flow>
     <flow name="strings-reader">
         <vm:inbound-endpoint path="strings-reader.in"
             exchange-pattern="request-response" />
-        <redis:get key="#[message.inboundProperties.key]" />
+        <redis:get config-ref="localRedis" key="#[message.inboundProperties.key]" />
     </flow>
     <flow name="key-existence">
         <vm:inbound-endpoint path="key-existence.in"
             exchange-pattern="request-response" />
-        <redis:exists key="#[message.inboundProperties.key]" />
+        <redis:exists config-ref="localRedis" key="#[message.inboundProperties.key]" />
     </flow>
 
     <flow name="incr-decr">
         <vm:inbound-endpoint path="incr-decr.in"
             exchange-pattern="request-response" />
-        <redis:increment key="#[message.inboundProperties.key]" />
-        <redis:increment key="#[message.inboundProperties.key]"
+        <redis:increment config-ref="localRedis" key="#[message.inboundProperties.key]" />
+        <redis:increment config-ref="localRedis" key="#[message.inboundProperties.key]"
             step="5" />
-        <redis:decrement key="#[message.inboundProperties.key]" />
-        <redis:decrement key="#[message.inboundProperties.key]"
+        <redis:decrement config-ref="localRedis" key="#[message.inboundProperties.key]" />
+        <redis:decrement config-ref="localRedis" key="#[message.inboundProperties.key]"
             step="7" />
     </flow>
 
@@ -49,30 +49,30 @@
         <vm:inbound-endpoint path="hashes-writer.in"
             exchange-pattern="request-response" />
         <all>
-            <redis:hash-set key="#[message.inboundProperties.key]"
+            <redis:hash-set config-ref="localRedis" key="#[message.inboundProperties.key]"
                 field="#[message.inboundProperties.field]" />
-            <redis:hash-set key="#[message.inboundProperties.key]"
+            <redis:hash-set config-ref="localRedis" key="#[message.inboundProperties.key]"
                 field="#[string:#[message.inboundProperties.field].other]"
                 ifNotExists="true" />
             <append-string-transformer message=".foo" />
-            <redis:hash-set key="#[message.inboundProperties.key]"
+            <redis:hash-set config-ref="localRedis" key="#[message.inboundProperties.key]"
                 field="#[message.inboundProperties.field]" ifNotExists="true" />
-            <redis:hash-set key="#[message.inboundProperties.key].value"
+            <redis:hash-set config-ref="localRedis" key="#[message.inboundProperties.key].value"
                 field="#[message.inboundProperties.field]" value="#[message.inboundProperties.key]" />
         </all>
     </flow>
     <flow name="hashes-reader">
         <vm:inbound-endpoint path="hashes-reader.in"
             exchange-pattern="request-response" />
-        <redis:hash-get key="#[message.inboundProperties.key]"
+        <redis:hash-get config-ref="localRedis" key="#[message.inboundProperties.key]"
             field="#[message.inboundProperties.field]" />
     </flow>
     <flow name="hashes-incr">
         <vm:inbound-endpoint path="hashes-incr.in"
             exchange-pattern="request-response" />
-        <redis:hash-increment key="#[message.inboundProperties.key]"
+        <redis:hash-increment config-ref="localRedis" key="#[message.inboundProperties.key]"
             field="#[message.inboundProperties.field]" />
-        <redis:hash-increment key="#[message.inboundProperties.key]"
+        <redis:hash-increment config-ref="localRedis" key="#[message.inboundProperties.key]"
             field="#[message.inboundProperties.field]" step="-5" />
     </flow>
 
@@ -80,22 +80,22 @@
         <vm:inbound-endpoint path="lists-writer.in"
             exchange-pattern="request-response" />
         <all>
-            <redis:list-push key="#[message.inboundProperties.key]"
+            <redis:list-push config-ref="localRedis" key="#[message.inboundProperties.key]"
                 side="LEFT" ifExists="true" />
-            <redis:list-push key="#[message.inboundProperties.key]"
+            <redis:list-push config-ref="localRedis" key="#[message.inboundProperties.key]"
                 side="RIGHT" ifExists="true" />
-            <redis:list-push key="#[message.inboundProperties.key]"
+            <redis:list-push config-ref="localRedis" key="#[message.inboundProperties.key]"
                 side="LEFT" />
-            <redis:list-push key="#[message.inboundProperties.key]"
+            <redis:list-push config-ref="localRedis" key="#[message.inboundProperties.key]"
                 side="RIGHT" />
-            <redis:list-push key="#[message.inboundProperties.key].value"
+            <redis:list-push config-ref="localRedis" key="#[message.inboundProperties.key].value"
                 value="#[message.inboundProperties.key]" side="RIGHT" />
         </all>
     </flow>
     <flow name="lists-reader">
         <vm:inbound-endpoint path="lists-reader.in"
             exchange-pattern="request-response" />
-        <redis:list-pop key="#[message.inboundProperties.key]"
+        <redis:list-pop config-ref="localRedis" key="#[message.inboundProperties.key]"
             side="#[message.inboundProperties.side]" />
     </flow>
 
@@ -104,11 +104,11 @@
             exchange-pattern="request-response" />
 
         <all>
-            <redis:set-add key="#[message.inboundProperties.key]" />
-            <redis:set-add key="#[message.inboundProperties.key]"
+            <redis:set-add config-ref="localRedis" key="#[message.inboundProperties.key]" />
+            <redis:set-add config-ref="localRedis" key="#[message.inboundProperties.key]"
                 mustSucceed="true" />
-            <redis:set-add key="#[message.inboundProperties.key]" />
-            <redis:set-add key="#[message.inboundProperties.key].value"
+            <redis:set-add config-ref="localRedis" key="#[message.inboundProperties.key]" />
+            <redis:set-add config-ref="localRedis" key="#[message.inboundProperties.key].value"
                 value="#[message.inboundProperties.key]" />
         </all>
     </flow>
@@ -116,10 +116,10 @@
         <vm:inbound-endpoint path="sets-reader.in"
             exchange-pattern="request-response" />
         <all>
-            <redis:set-fetch-random-member key="#[message.inboundProperties.key]" />
-            <redis:set-pop key="#[message.inboundProperties.key]" />
-            <redis:set-pop key="#[message.inboundProperties.key]" />
-            <redis:set-pop key="#[message.inboundProperties.key].value" />
+            <redis:set-fetch-random-member config-ref="localRedis" key="#[message.inboundProperties.key]" />
+            <redis:set-pop config-ref="localRedis" key="#[message.inboundProperties.key]" />
+            <redis:set-pop config-ref="localRedis" key="#[message.inboundProperties.key]" />
+            <redis:set-pop config-ref="localRedis" key="#[message.inboundProperties.key].value" />
         </all>
     </flow>
 
@@ -128,13 +128,13 @@
             exchange-pattern="request-response" />
 
         <all>
-            <redis:sorted-set-add key="#[message.inboundProperties.key]"
+            <redis:sorted-set-add config-ref="localRedis" key="#[message.inboundProperties.key]"
                 score="#[message.inboundProperties.score]" />
-            <redis:sorted-set-add key="#[message.inboundProperties.key]"
+            <redis:sorted-set-add config-ref="localRedis" key="#[message.inboundProperties.key]"
                 score="#[message.inboundProperties.score]" mustSucceed="true" />
-            <redis:sorted-set-add key="#[message.inboundProperties.key]"
+            <redis:sorted-set-add config-ref="localRedis" key="#[message.inboundProperties.key]"
                 score="#[message.inboundProperties.score]" />
-            <redis:sorted-set-add key="#[message.inboundProperties.key].value"
+            <redis:sorted-set-add config-ref="localRedis" key="#[message.inboundProperties.key].value"
                 score="#[message.inboundProperties.score]" value="#[message.inboundProperties.key]" />
         </all>
     </flow>
@@ -142,14 +142,14 @@
         <vm:inbound-endpoint path="sorted-sets-reader.in"
             exchange-pattern="request-response" />
         <all>
-            <redis:sorted-set-select-range-by-index
+            <redis:sorted-set-select-range-by-index config-ref="localRedis"
                 key="#[message.inboundProperties.key]" start="0" end="-1" />
-            <redis:sorted-set-select-range-by-index
+            <redis:sorted-set-select-range-by-index config-ref="localRedis"
                 key="#[message.inboundProperties.key]" start="0" end="-1"
                 order="DESCENDING" />
-            <redis:sorted-set-select-range-by-score
+            <redis:sorted-set-select-range-by-score config-ref="localRedis"
                 key="#[message.inboundProperties.key]" min="0.5" max="10" />
-            <redis:sorted-set-select-range-by-score
+            <redis:sorted-set-select-range-by-score config-ref="localRedis"
                 key="#[message.inboundProperties.key]" min="10" max="0.5" order="DESCENDING" />
         </all>
     </flow>
@@ -158,9 +158,9 @@
         <vm:inbound-endpoint path="sorted-set-incr.in"
             exchange-pattern="request-response" />
         <all>
-            <redis:sorted-set-increment key="#[message.inboundProperties.key]"
+            <redis:sorted-set-increment config-ref="localRedis" key="#[message.inboundProperties.key]"
                 step="3.14" />
-            <redis:sorted-set-increment key="#[message.inboundProperties.key].value"
+            <redis:sorted-set-increment config-ref="localRedis" key="#[message.inboundProperties.key].value"
                 value="#[message.inboundProperties.key]" step="2.72" />
         </all>
     </flow>
@@ -169,16 +169,16 @@
         <vm:inbound-endpoint path="key-volatility.in"
             exchange-pattern="request-response" />
 
-        <redis:set key="#[message.inboundProperties.key]" />
+        <redis:set config-ref="localRedis" key="#[message.inboundProperties.key]" />
 
         <all>
-            <redis:expire-at key="#[message.inboundProperties.key]"
+            <redis:expire-at config-ref="localRedis" key="#[message.inboundProperties.key]"
                 unixTime="#[message.inboundProperties.expireAtUnixTime]" />
-            <redis:expire key="#[message.inboundProperties.key]"
+            <redis:expire config-ref="localRedis" key="#[message.inboundProperties.key]"
                 seconds="20" />
-            <redis:get-ttl key="#[message.inboundProperties.key]" />
-            <redis:persist key="#[message.inboundProperties.key]" />
-            <redis:get-ttl key="#[message.inboundProperties.key]" />
+            <redis:get-ttl config-ref="localRedis" key="#[message.inboundProperties.key]" />
+            <redis:persist config-ref="localRedis" key="#[message.inboundProperties.key]" />
+            <redis:get-ttl config-ref="localRedis" key="#[message.inboundProperties.key]" />
         </all>
     </flow>
 </mule>

--- a/src/test/resources/redis-objectstore-tests-config.xml
+++ b/src/test/resources/redis-objectstore-tests-config.xml
@@ -34,14 +34,16 @@
     <!--
          Full Config
     -->
-<!--     <spring:beans>
+    <spring:beans>
         <spring:bean name="redisPoolConfiguration" class="org.apache.commons.pool2.impl.GenericObjectPoolConfig"
             p:blockWhenExhausted="true" />
-    </spring:beans> -->
+    </spring:beans>
 
     <redis:config name="localRedisFullConfig" host="localhost"
         port="6379" password="s3cre3t" connectionTimeout="15000"
-        reconnectionFrequency="60000"/>
+        reconnectionFrequency="60000">
+        <redis:pool-config ref="redisPoolConfiguration"/>
+     </redis:config>
 
     <flow name="idempotentFlow">
         <vm:inbound-endpoint path="idempotentFlow.in" />

--- a/src/test/resources/redis-objectstore-tests-config.xml
+++ b/src/test/resources/redis-objectstore-tests-config.xml
@@ -16,14 +16,21 @@
     </configuration>
 
     <spring:beans>
-        <spring:bean class="org.mule.module.redis.FakeObjectStoreUser"
+        <spring:bean name="fakeObjectStoreUser" class="org.mule.module.redis.FakeObjectStoreUser"
             p:objectStore-ref="localRedis" />
+        <spring:bean name="fakeObjectStoreUserExpirable" class="org.mule.module.redis.FakeObjectStoreUser"
+            p:objectStore-ref="localRedisExpirableStore" />
     </spring:beans>
 
     <!--
          Minimal Config
     -->
     <redis:config name="localRedis" />
+    
+    <!--  
+       Minimal store with configuration 
+   -->
+   <redis:config name="localRedisExpirableStore" partitionExpiry="10" defaultPartitionName="RedisExpiryIntegrationTest"/>
 
     <!--
          Minimal Config with default objectstore partition name using an expression

--- a/src/test/resources/redis-objectstore-tests-config.xml
+++ b/src/test/resources/redis-objectstore-tests-config.xml
@@ -34,14 +34,14 @@
     <!--
          Full Config
     -->
-    <spring:beans>
-        <spring:bean name="redisPoolConfiguration" class="redis.clients.jedis.JedisPoolConfig"
-            p:whenExhaustedAction="#{T(org.apache.commons.pool.impl.GenericObjectPool).WHEN_EXHAUSTED_GROW}" />
-    </spring:beans>
+<!--     <spring:beans>
+        <spring:bean name="redisPoolConfiguration" class="org.apache.commons.pool2.impl.GenericObjectPoolConfig"
+            p:blockWhenExhausted="true" />
+    </spring:beans> -->
 
     <redis:config name="localRedisFullConfig" host="localhost"
         port="6379" password="s3cre3t" connectionTimeout="15000"
-        reconnectionFrequency="60000" poolConfig-ref="redisPoolConfiguration" />
+        reconnectionFrequency="60000"/>
 
     <flow name="idempotentFlow">
         <vm:inbound-endpoint path="idempotentFlow.in" />

--- a/src/test/resources/redis-pubsub-tests-config.xml
+++ b/src/test/resources/redis-pubsub-tests-config.xml
@@ -7,17 +7,17 @@
           http://www.mulesoft.org/schema/mule/vm http://www.mulesoft.org/schema/mule/vm/current/mule-vm.xsd
           http://www.mulesoft.org/schema/mule/test http://www.mulesoft.org/schema/mule/test/current/mule-test.xsd">
 
-    <redis:config />
+    <redis:config name="localRedis" />
 
     <flow name="publisher">
         <vm:inbound-endpoint path="publisher.in" />
-        <redis:publish channel="#[message.inboundProperties['target-channel']]" />
+        <redis:publish channel="#[message.inboundProperties['target-channel']]" config-ref="localRedis"/>
         <redis:publish channel="#[message.inboundProperties['target-channel']]"
-            message="#[message.inboundProperties['second-message-payload']]" />
+            message="#[message.inboundProperties['second-message-payload']]" config-ref="localRedis" />
     </flow>
 
     <flow name="subscriber">
-        <redis:subscribe>
+        <redis:subscribe config-ref="localRedis">
             <!-- Channels are selected by patterns -->
             <redis:channels>
                 <redis:channel>mule.test.single.channel</redis:channel>


### PR DESCRIPTION
- Upgrade to Jedis 2.8.0, 
- Add support for redis Sentinel
- Upgrade to devkit 3.7.2. 
- Add expiration parameter for partition when used as objectstore
- Add workaround to make possible the usage of the module as objectstore for the enterprise cache scope.